### PR TITLE
Fix - Import History Grid Rendering Empty HTML tag

### DIFF
--- a/app/code/Magento/ImportExport/Block/Adminhtml/Grid/Column/Renderer/Download.php
+++ b/app/code/Magento/ImportExport/Block/Adminhtml/Grid/Column/Renderer/Download.php
@@ -20,9 +20,16 @@ class Download extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\Text
      */
     public function _getValue(\Magento\Framework\DataObject $row)
     {
-        return '<p> ' . $row->getData('imported_file') .  '</p><a href="'
-        . $this->getUrl('*/*/download', ['filename' => $row->getData('imported_file')]) . '">'
-        . __('Download')
-        . '</a>';
+        if ($row->getData('imported_file')) {
+			return '<p> ' . $row->getData('imported_file') .  '</p><a href="'
+            . $this->getUrl('*/*/download', ['filename' => $row->getData('imported_file')]) . '">'
+            . __('Download')
+            . '</a>';
+        } else {
+            return '<a href="'
+            . $this->getUrl('*/*/download', ['filename' => $row->getData('imported_file')]) . '">'
+            . __('Download')
+            . '</a>';
+        }
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#24456: Import History Grid Rendering Empty HTML tag, when there is no import file name.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. In admin navigate to System > Import History.
2. After this fix the Empty paragraph tag is not rendered.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
